### PR TITLE
Update base URL

### DIFF
--- a/pykoa/koa/__init__.py
+++ b/pykoa/koa/__init__.py
@@ -10,7 +10,7 @@ class Conf (_config.ConfigNamespace):
     Configuration parameters for 'astroquery.koa'.
     """
     server = _config.ConfigItem (
-        ['https://koa.ipac.caltech.edu/cgi-bin/'],
+        ['https://koa.ipac.caltech.edu/'],
         'Name of the KOA server to use.') 
 
     timeout = _config.ConfigItem (


### PR DESCRIPTION
The ``cgi-bin`` string appeared twice in the generated URLs.  This PR takes it out of the config item in ``__init__.py``.